### PR TITLE
Add `-Wno-conversion` C flag to suppress "Implicit conversion loses integer precision" warnings on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,7 @@ let package = Package(
         .define("HAVE_FULLFSYNC", to: "1"),
         .headerSearchPath("./"),
         .headerSearchPath("include/"),
+        .unsafeFlags(["-w"]),
       ]
     ),
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ let package = Package(
         .define("HAVE_FULLFSYNC", to: "1"),
         .headerSearchPath("./"),
         .headerSearchPath("include/"),
-        .unsafeFlags(["-w"]),
+        .unsafeFlags(["-Wno-conversion"]),
       ]
     ),
   ],


### PR DESCRIPTION
To fix https://github.com/firebase/firebase-ios-sdk/issues/12043 I added the `-Wno-conversion` C flag.