### PR TITLE
Manually fix implicit integer conversion warnings on iOS

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1085,7 +1085,7 @@ Iterator* DBImpl::NewInternalIterator(const ReadOptions& options,
   }
   versions_->current()->AddIterators(options, &list);
   Iterator* internal_iter =
-      NewMergingIterator(&internal_comparator_, &list[0], list.size());
+      NewMergingIterator(&internal_comparator_, &list[0], (uint32_t)list.size());
   versions_->current()->Ref();
 
   IterState* cleanup = new IterState(&mutex_, mem_, imm_, versions_->current());

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -124,7 +124,7 @@ LookupKey::LookupKey(const Slice& user_key, SequenceNumber s) {
     dst = new char[needed];
   }
   start_ = dst;
-  dst = EncodeVarint32(dst, usize + 8);
+  dst = EncodeVarint32(dst, (uint32_t)usize + 8);
   kstart_ = dst;
   std::memcpy(dst, user_key.data(), usize);
   dst += usize;

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -38,7 +38,7 @@ int MemTable::KeyComparator::operator()(const char* aptr,
 // into this scratch space.
 static const char* EncodeKey(std::string* scratch, const Slice& target) {
   scratch->clear();
-  PutVarint32(scratch, target.size());
+  PutVarint32(scratch, (uint32_t)target.size());
   scratch->append(target.data(), target.size());
   return scratch->data();
 }
@@ -87,12 +87,12 @@ void MemTable::Add(SequenceNumber s, ValueType type, const Slice& key,
                              internal_key_size + VarintLength(val_size) +
                              val_size;
   char* buf = arena_.Allocate(encoded_len);
-  char* p = EncodeVarint32(buf, internal_key_size);
+  char* p = EncodeVarint32(buf, (uint32_t)internal_key_size);
   std::memcpy(p, key.data(), key_size);
   p += key_size;
   EncodeFixed64(p, (s << 8) | type);
   p += 8;
-  p = EncodeVarint32(p, val_size);
+  p = EncodeVarint32(p, (uint32_t)val_size);
   std::memcpy(p, value.data(), val_size);
   assert(p + val_size == buf + encoded_len);
   table_.Insert(buf);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -87,7 +87,7 @@ Version::~Version() {
 int FindFile(const InternalKeyComparator& icmp,
              const std::vector<FileMetaData*>& files, const Slice& key) {
   uint32_t left = 0;
-  uint32_t right = files.size();
+  uint32_t right = (uint32_t)files.size();
   while (left < right) {
     uint32_t mid = (left + right) / 2;
     const FileMetaData* f = files[mid];
@@ -164,7 +164,7 @@ class Version::LevelFileNumIterator : public Iterator {
  public:
   LevelFileNumIterator(const InternalKeyComparator& icmp,
                        const std::vector<FileMetaData*>* flist)
-      : icmp_(icmp), flist_(flist), index_(flist->size()) {  // Marks as invalid
+      : icmp_(icmp), flist_(flist), index_((uint32_t)flist->size()) {  // Marks as invalid
   }
   bool Valid() const override { return index_ < flist_->size(); }
   void Seek(const Slice& target) override {
@@ -172,7 +172,7 @@ class Version::LevelFileNumIterator : public Iterator {
   }
   void SeekToFirst() override { index_ = 0; }
   void SeekToLast() override {
-    index_ = flist_->empty() ? 0 : flist_->size() - 1;
+    index_ = flist_->empty() ? 0 : (uint32_t)flist_->size() - 1;
   }
   void Next() override {
     assert(Valid());
@@ -181,7 +181,7 @@ class Version::LevelFileNumIterator : public Iterator {
   void Prev() override {
     assert(Valid());
     if (index_ == 0) {
-      index_ = flist_->size();  // Marks as invalid
+      index_ = (uint32_t)flist_->size();  // Marks as invalid
     } else {
       index_--;
     }
@@ -1094,7 +1094,7 @@ Status VersionSet::WriteSnapshot(log::Writer* log) {
 int VersionSet::NumLevelFiles(int level) const {
   assert(level >= 0);
   assert(level < config::kNumLevels);
-  return current_->files_[level].size();
+  return (uint32_t)current_->files_[level].size();
 }
 
 const char* VersionSet::LevelSummary(LevelSummaryStorage* scratch) const {
@@ -1219,7 +1219,7 @@ Iterator* VersionSet::MakeInputIterator(Compaction* c) {
   // Level-0 files have to be merged together.  For other levels,
   // we will make a concatenating iterator per level.
   // TODO(opt): use concatenating iterator for level-0 if there is no overlap
-  const int space = (c->level() == 0 ? c->inputs_[0].size() + 1 : 2);
+  const int space = (c->level() == 0 ? (uint32_t)c->inputs_[0].size() + 1 : 2);
   Iterator** list = new Iterator*[space];
   int num = 0;
   for (int which = 0; which < 2; which++) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -109,7 +109,7 @@ class Version {
   int PickLevelForMemTableOutput(const Slice& smallest_user_key,
                                  const Slice& largest_user_key);
 
-  int NumFiles(int level) const { return files_[level].size(); }
+  int NumFiles(int level) const { return (uint32_t)files_[level].size(); }
 
   // Return a human readable string that describes this version's contents.
   std::string DebugString() const;
@@ -329,7 +329,7 @@ class Compaction {
   VersionEdit* edit() { return &edit_; }
 
   // "which" must be either 0 or 1
-  int num_input_files(int which) const { return inputs_[which].size(); }
+  int num_input_files(int which) const { return (uint32_t)inputs_[which].size(); }
 
   // Return the ith input file at "level()+which" ("which" must be 0 or 1).
   FileMetaData* input(int which, int i) const { return inputs_[which][i]; }

--- a/table/block.cc
+++ b/table/block.cc
@@ -34,7 +34,7 @@ Block::Block(const BlockContents& contents)
       // The size is too small for NumRestarts()
       size_ = 0;
     } else {
-      restart_offset_ = size_ - (1 + NumRestarts()) * sizeof(uint32_t);
+      restart_offset_ = (uint32_t)size_ - (1 + NumRestarts()) * sizeof(uint32_t);
     }
   }
 }
@@ -94,7 +94,7 @@ class Block::Iter : public Iterator {
 
   // Return the offset in data_ just past the end of the current entry.
   inline uint32_t NextEntryOffset() const {
-    return (value_.data() + value_.size()) - data_;
+    return (uint32_t)((value_.data() + value_.size()) - data_);
   }
 
   uint32_t GetRestartPoint(uint32_t index) {

--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -63,7 +63,7 @@ Slice BlockBuilder::Finish() {
   for (size_t i = 0; i < restarts_.size(); i++) {
     PutFixed32(&buffer_, restarts_[i]);
   }
-  PutFixed32(&buffer_, restarts_.size());
+  PutFixed32(&buffer_, (uint32_t)restarts_.size());
   finished_ = true;
   return Slice(buffer_);
 }
@@ -74,7 +74,7 @@ void BlockBuilder::Add(const Slice& key, const Slice& value) {
   assert(counter_ <= options_->block_restart_interval);
   assert(buffer_.empty()  // No values yet?
          || options_->comparator->Compare(key, last_key_piece) > 0);
-  size_t shared = 0;
+  uint32_t shared = 0;
   if (counter_ < options_->block_restart_interval) {
     // See how much sharing to do with previous string
     const size_t min_length = std::min(last_key_piece.size(), key.size());
@@ -83,15 +83,15 @@ void BlockBuilder::Add(const Slice& key, const Slice& value) {
     }
   } else {
     // Restart compression
-    restarts_.push_back(buffer_.size());
+    restarts_.push_back((uint32_t)buffer_.size());
     counter_ = 0;
   }
   const size_t non_shared = key.size() - shared;
 
   // Add "<shared><non_shared><value_size>" to buffer_
   PutVarint32(&buffer_, shared);
-  PutVarint32(&buffer_, non_shared);
-  PutVarint32(&buffer_, value.size());
+  PutVarint32(&buffer_, (uint32_t)non_shared);
+  PutVarint32(&buffer_, (uint32_t)value.size());
 
   // Add string delta to buffer_ followed by value
   buffer_.append(key.data() + shared, non_shared);

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -38,7 +38,7 @@ Slice FilterBlockBuilder::Finish() {
   }
 
   // Append array of per-filter offsets
-  const uint32_t array_offset = result_.size();
+  const uint32_t array_offset = (uint32_t)result_.size();
   for (size_t i = 0; i < filter_offsets_.size(); i++) {
     PutFixed32(&result_, filter_offsets_[i]);
   }
@@ -52,7 +52,7 @@ void FilterBlockBuilder::GenerateFilter() {
   const size_t num_keys = start_.size();
   if (num_keys == 0) {
     // Fast path if there are no keys for this filter
-    filter_offsets_.push_back(result_.size());
+    filter_offsets_.push_back((uint32_t)result_.size());
     return;
   }
 
@@ -66,7 +66,7 @@ void FilterBlockBuilder::GenerateFilter() {
   }
 
   // Generate filter for current set of keys and append to result_.
-  filter_offsets_.push_back(result_.size());
+  filter_offsets_.push_back((uint32_t)result_.size());
   policy_->CreateFilter(&tmp_keys_[0], static_cast<int>(num_keys), &result_);
 
   tmp_keys_.clear();

--- a/util/coding.cc
+++ b/util/coding.cc
@@ -70,7 +70,7 @@ void PutVarint64(std::string* dst, uint64_t v) {
 }
 
 void PutLengthPrefixedSlice(std::string* dst, const Slice& value) {
-  PutVarint32(dst, value.size());
+  PutVarint32(dst, (uint32_t)value.size());
   dst->append(value.data(), value.size());
 }
 

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -765,7 +765,7 @@ int MaxOpenFiles() {
     g_open_read_only_file_limit = std::numeric_limits<int>::max();
   } else {
     // Allow use of 20% of available file descriptors for read-only files.
-    g_open_read_only_file_limit = rlim.rlim_cur / 5;
+    g_open_read_only_file_limit = (uint32_t)rlim.rlim_cur / 5;
   }
   return g_open_read_only_file_limit;
 }

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -24,7 +24,7 @@ uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   const uint32_t m = 0xc6a4a793;
   const uint32_t r = 24;
   const char* limit = data + n;
-  uint32_t h = seed ^ (n * m);
+  uint32_t h = seed ^ ((uint32_t)n * m);
 
   // Pick up four bytes at a time
   while (data + 4 <= limit) {


### PR DESCRIPTION
..by explicitly casting to 32 bit integers. This is to address https://github.com/firebase/firebase-ios-sdk/issues/12043