### PR TITLE
[Infra] Don't trigger CI jobs twice on each PR commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: ci
 
 on:
-  push:
   pull_request:
 
 concurrency:


### PR DESCRIPTION
See that this PR has 6 checks while #5 had 11 checks: https://github.com/firebase/leveldb/pull/5/checks

Aligned with the triggers used in the Firebase repo. Example

https://github.com/firebase/firebase-ios-sdk/blob/ae68344a883c08400e9f811bd15195b8d0f14abf/.github/workflows/core.yml#L4

