### PR TITLE
fix C++20 compliance with application of upstream PR 965

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -837,7 +837,7 @@ class SingletonEnv {
  public:
   SingletonEnv() {
 #if !defined(NDEBUG)
-    env_initialized_.store(true, std::memory_order::memory_order_relaxed);
+    env_initialized_.store(true, std::memory_order_relaxed);
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
@@ -854,7 +854,7 @@ class SingletonEnv {
 
   static void AssertEnvNotInitialized() {
 #if !defined(NDEBUG)
-    assert(!env_initialized_.load(std::memory_order::memory_order_relaxed));
+    assert(!env_initialized_.load(std::memory_order_relaxed));
 #endif  // !defined(NDEBUG)
   }
 


### PR DESCRIPTION
These symbols are no longer valid on macOS and will fail builds if the `NDEBUG` symbol is !defined, as it is now in default build settings for all react-native projects since release of react-native 0.76

This same change was applied upstream but never released, and it appears it has not been applied here

https://github.com/google/leveldb/pull/965#issuecomment-2436371816

See: https://github.com/invertase/react-native-firebase/issues/8082#issuecomment-2436363510

It would be fantastic to get a leveldb release with this fix, that firebase-ios-sdk adopted, so react-native-firebase was compatible with firebase-ios-sdk out of the box again with react-native 0.76

Thanks!